### PR TITLE
Allow to enter paths to files as dest

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "standard.enable": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "standard.enable": true
-}

--- a/bin/micro-proxy
+++ b/bin/micro-proxy
@@ -44,13 +44,15 @@ if (!rulesFile) {
   process.exit(1)
 }
 
-const rulesFilePath = resolve(process.cwd(), rulesFile)
-const { rules } = require(rulesFilePath)
-const proxy = buildProxy(rules)
-proxy.listen(port, hostname, (err) => {
-  if (err) {
-    throw err
-  }
-
-  console.log(`> Ready on http://${hostname}:${port}`)
-})
+(async () => {
+  const rulesFilePath = resolve(process.cwd(), rulesFile)
+  const { rules } = require(rulesFilePath)
+  const proxy = await buildProxy(rules)
+  proxy.listen(port, hostname, (err) => {
+    if (err) {
+      throw err
+    }
+  
+    console.log(`> Ready on http://${hostname}:${port}`)
+  })
+})()

--- a/bin/micro-proxy
+++ b/bin/micro-proxy
@@ -45,9 +45,10 @@ if (!rulesFile) {
 }
 
 (async () => {
-  const rulesFilePath = resolve(process.cwd(), rulesFile)
+  const rulesDirectoryPath = process.cwd()
+  const rulesFilePath = resolve(rulesDirectoryPath, rulesFile)
   const { rules } = require(rulesFilePath)
-  const proxy = await buildProxy(rules)
+  const proxy = await buildProxy(rules, rulesDirectoryPath)
   proxy.listen(port, hostname, (err) => {
     if (err) {
       throw err

--- a/index.js
+++ b/index.js
@@ -2,8 +2,9 @@ const micro = require('micro')
 const { resolve } = require('url')
 const fetch = require('node-fetch')
 const lintRules = require('./lib/lint-rules')
+const mountRules = require('./lib/mount-rules')
 
-module.exports = (rules) => {
+module.exports = async (rules) => {
   const lintedRules = lintRules(rules).map(({pathname, pathnameRe, method, dest}) => {
     const methods = method ? method.reduce((final, c) => {
       final[c.toLowerCase()] = true
@@ -18,8 +19,10 @@ module.exports = (rules) => {
     }
   })
 
+  const mountedRules = await mountRules(lintedRules)
+
   return micro(async (req, res) => {
-    for (const { pathnameRegexp, methods, dest } of lintedRules) {
+    for (const { pathnameRegexp, methods, dest } of mountedRules) {
       if (pathnameRegexp.test(req.url) && (!methods || methods[req.method.toLowerCase()])) {
         await proxyRequest(req, res, dest)
         return

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const fetch = require('node-fetch')
 const lintRules = require('./lib/lint-rules')
 const mountRules = require('./lib/mount-rules')
 
-module.exports = async (rules) => {
+module.exports = async (rules, rulesDirectoryPath = process.cwd()) => {
   const lintedRules = lintRules(rules).map(({pathname, pathnameRe, method, dest}) => {
     const methods = method ? method.reduce((final, c) => {
       final[c.toLowerCase()] = true
@@ -19,7 +19,7 @@ module.exports = async (rules) => {
     }
   })
 
-  const mountedRules = await mountRules(lintedRules)
+  const mountedRules = await mountRules(lintedRules, rulesDirectoryPath)
 
   const service = micro(async (req, res) => {
     for (const { pathnameRegexp, methods, dest } of mountedRules) {

--- a/lib/lint-rules.js
+++ b/lib/lint-rules.js
@@ -83,6 +83,11 @@ function lintDest (rule) {
     throw err
   }
 
+  // If dest is a file, it should be in the format ./XXX
+  if (rule.dest.slice(0,2) === './') {
+    return rule
+  }
+
   const {
     host,
     protocol

--- a/lib/mount-rules.js
+++ b/lib/mount-rules.js
@@ -1,0 +1,29 @@
+const micro = require('micro')
+const listen = require('test-listen')
+
+module.exports = (rules) => Promise.all(
+  rules.map(async ({ dest, ...rest }) => {
+    let mountedDest = dest
+
+    // If dest is a file, mount the micro service
+    // and replace the file path by the mounted url
+    if (dest.slice(0, 2) === './') {
+      try {
+        const service = require(`../${dest}`)
+        mountedDest = await listen(micro(service))
+      } catch (e) {
+        if (e.code === 'MODULE_NOT_FOUND') {
+          const err = new Error(`Dest file not found ${dest}`)
+          err.statusCode = 422
+          throw err
+        }
+        throw e
+      }
+    }
+
+    return {
+      dest: mountedDest,
+      ...rest
+    }
+  })
+)

--- a/lib/mount-rules.js
+++ b/lib/mount-rules.js
@@ -4,13 +4,15 @@ const listen = require('test-listen')
 module.exports = (rules) => Promise.all(
   rules.map(async ({ dest, ...rest }) => {
     let mountedDest = dest
+    let service = null
 
     // If dest is a file, mount the micro service
     // and replace the file path by the mounted url
     if (dest.slice(0, 2) === './') {
       try {
-        const service = require(`../${dest}`)
-        mountedDest = await listen(micro(service))
+        const func = require(`../${dest}`)
+        service = micro(func)
+        mountedDest = await listen(service)
       } catch (e) {
         if (e.code === 'MODULE_NOT_FOUND') {
           const err = new Error(`Dest file not found ${dest}`)
@@ -23,6 +25,7 @@ module.exports = (rules) => Promise.all(
 
     return {
       dest: mountedDest,
+      service,
       ...rest
     }
   })

--- a/lib/mount-rules.js
+++ b/lib/mount-rules.js
@@ -1,7 +1,8 @@
 const micro = require('micro')
 const listen = require('test-listen')
+const { resolve } = require('path')
 
-module.exports = (rules) => Promise.all(
+module.exports = (rules, rulesDirectoryPath) => Promise.all(
   rules.map(async ({ dest, ...rest }) => {
     let mountedDest = dest
     let service = null
@@ -10,9 +11,11 @@ module.exports = (rules) => Promise.all(
     // and replace the file path by the mounted url
     if (dest.slice(0, 2) === './') {
       try {
-        const func = require(`../${dest}`)
+        const destFilePath = resolve(rulesDirectoryPath, dest)
+        const func = require(destFilePath)
         service = micro(func)
         mountedDest = await listen(service)
+        console.log(`. Started ${dest} on ${mountedDest}`)
       } catch (e) {
         if (e.code === 'MODULE_NOT_FOUND') {
           const err = new Error(`Dest file not found ${dest}`)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "arg": "^1.0.0",
     "micro": "^9.0.2",
-    "node-fetch": "^1.7.3"
+    "node-fetch": "^1.7.3",
+    "test-listen": "^1.1.0"
   },
   "engines": {
     "node": ">=8.0.0"
@@ -26,7 +27,6 @@
   "devDependencies": {
     "jest": "^21.2.1",
     "standard": "^10.0.3",
-    "tempfile": "^2.0.0",
-    "test-listen": "^1.1.0"
+    "tempfile": "^2.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,24 @@ micro-proxy -r rules.json -p 9000
 
 Now you can access the proxy via: `http://localhost:9000`
 
+### Proxying a file containing your micro function
+
+You can also enter a path to a file containing your micro function in `dest`.
+
+First, create `src/hello.js` :
+```js
+module.exports = module.exports = () => 'hello world'
+```
+
+Then, add this rule to the file `rules.json` :
+```json
+{
+  "rules": [
+    {"pathname": "/hello", "dest": "./src/hello.js"}
+  ]
+}
+```
+
 ### Programmatic Usage
 
 You can run the proxy programmatically inside your codebase.
@@ -50,6 +68,7 @@ Then create the proxy server like this:
 const createProxy = require('micro-proxy')
 const proxy = createProxy([
   {"pathname": "/blog", "method":["GET", "POST", "OPTIONS"], "dest": "http://localhost:5000"},
+  {"pathname": "/hello", "dest": "./src/hello.js"},
   {"pathname": "/**", "dest": "http://localhost:4000"}
 ])
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -8,12 +8,17 @@ describe('CLI commands', () => {
   it('should load rules from a file', async () => {
     const s1 = await createInfoServer()
     const proxy = await startProxyCLI([
-      { pathname: '/blog/**', dest: s1.url }
+      { pathname: '/blog/**', dest: s1.url },
+      { pathname: '/hello', dest: './test/fixtures/micro-example.js' }
     ])
 
-    const res = await fetch('http://localhost:9000/blog/hello')
-    const data = await res.json()
-    expect(data.url).toBe('/blog/hello')
+    const res1 = await fetch('http://localhost:9000/blog/hello')
+    const data1 = await res1.json()
+    expect(data1.url).toBe('/blog/hello')
+
+    const res2 = await fetch('http://localhost:9000/hello')
+    const data2 = await res2.json()
+    expect(data2.message).toBe('hello world')
 
     s1.close()
     proxy.close()

--- a/test/fixtures/micro-example.js
+++ b/test/fixtures/micro-example.js
@@ -1,0 +1,3 @@
+module.exports = () => ({
+  message: 'hello world'
+})

--- a/test/fixtures/rules.json
+++ b/test/fixtures/rules.json
@@ -1,5 +1,6 @@
 {
   "rules": [
-    { "pathname": "/blog/**", "dest": "http://localhost:6070" }
+    { "pathname": "/blog/**", "dest": "http://localhost:6070" },
+    { "pathname": "/hello", "dest": "./test/fixtures/micro-example.js" }
   ]
 }

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -10,7 +10,7 @@ describe('Basic Proxy Operations', () => {
   describe('rules', () => {
     it('should proxy with a exactly matching pathname rule', async () => {
       const s1 = await createInfoServer()
-      const proxy = createProxy([
+      const proxy = await createProxy([
         { pathname: '/abc', dest: s1.url }
       ])
       await listen(proxy)
@@ -24,7 +24,7 @@ describe('Basic Proxy Operations', () => {
 
     it('should proxy with a wildcard matching pathname rule', async () => {
       const s1 = await createInfoServer()
-      const proxy = createProxy([
+      const proxy = await createProxy([
         { pathname: '/abc', dest: 'http://localhost' },
         { pathname: '/blog/**', dest: s1.url }
       ])
@@ -39,7 +39,7 @@ describe('Basic Proxy Operations', () => {
 
     it('should proxy with no pathname as the catch all rule', async () => {
       const s1 = await createInfoServer()
-      const proxy = createProxy([
+      const proxy = await createProxy([
         { pathname: '/abc', dest: 'http://localhost' },
         { pathname: '/blog/**', dest: s1.url }
       ])
@@ -54,7 +54,7 @@ describe('Basic Proxy Operations', () => {
 
     it('should send 404 if no matching rule found', async () => {
       const s1 = await createInfoServer()
-      const proxy = createProxy([
+      const proxy = await createProxy([
         { pathname: '/abc', dest: 'http://localhost' }
       ])
       await listen(proxy)
@@ -68,7 +68,7 @@ describe('Basic Proxy Operations', () => {
 
     it('should proxy to the first matching rule', async () => {
       const s1 = await createInfoServer()
-      const proxy = createProxy([
+      const proxy = await createProxy([
         { pathname: '/abc/**', dest: s1.url },
         { pathname: '/abc/blog/**', dest: 'http://localhost' }
       ])
@@ -80,12 +80,24 @@ describe('Basic Proxy Operations', () => {
       proxy.close()
       s1.close()
     })
+
+    it('should proxy with a file path as dest', async () => {
+      const proxy = await createProxy([
+        { pathname: '/hello', dest: './test/fixtures/micro-example.js' }
+      ])
+      await listen(proxy)
+
+      const { data } = await fetchProxy(proxy, '/hello')
+      expect(data.message).toBe('hello world')
+
+      proxy.close()
+    })
   })
 
   describe('methods', () => {
     it('should proxy for a method in the list', async () => {
       const s1 = await createInfoServer()
-      const proxy = createProxy([
+      const proxy = await createProxy([
         { pathname: '/blog/**', method: ['GET', 'POST'], dest: s1.url }
       ])
       await listen(proxy)
@@ -99,7 +111,7 @@ describe('Basic Proxy Operations', () => {
 
     it('should not proxy for a method which is not in the list', async () => {
       const s1 = await createInfoServer()
-      const proxy = createProxy([
+      const proxy = await createProxy([
         { pathname: '/blog/**', method: ['GET', 'POST'], dest: s1.url }
       ])
       await listen(proxy)
@@ -113,7 +125,7 @@ describe('Basic Proxy Operations', () => {
 
     it('should proxy for any method if no methods provided', async () => {
       const s1 = await createInfoServer()
-      const proxy = createProxy([
+      const proxy = await createProxy([
         { pathname: '/blog/**', dest: s1.url }
       ])
       await listen(proxy)
@@ -129,7 +141,7 @@ describe('Basic Proxy Operations', () => {
   describe('other', () => {
     it('should proxy the POST body', async () => {
       const s1 = await createInfoServer()
-      const proxy = createProxy([
+      const proxy = await createProxy([
         { pathname: '/blog/**', dest: s1.url }
       ])
       await listen(proxy)
@@ -148,7 +160,7 @@ describe('Basic Proxy Operations', () => {
 
     it('should forward request headers', async () => {
       const s1 = await createInfoServer()
-      const proxy = createProxy([
+      const proxy = await createProxy([
         { pathname: '/blog/**', dest: s1.url }
       ])
       await listen(proxy)
@@ -177,7 +189,7 @@ describe('Basic Proxy Operations', () => {
       })
       await listen(s1)
 
-      const proxy = createProxy([
+      const proxy = await createProxy([
         { pathname: '/blog/**', dest: `http://localhost:${s1.address().port}` }
       ])
       await listen(proxy)

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -90,7 +90,7 @@ describe('Basic Proxy Operations', () => {
       const { data } = await fetchProxy(proxy, '/hello')
       expect(data.message).toBe('hello world')
 
-      proxy.close()
+      proxy.closeAll()
     })
   })
 


### PR DESCRIPTION
Hello,

This PR is a suggestion to allow to enter paths to files as `dest`in the rules, like this :
```json
{
  "rules": [
    { "pathname": "/hello", "dest": "./src/hello.js" }
  ]
}
```

With, for example, the following `src/hello.js` file :
```js
module.exports = () => 'hello world'
```

I am using `test-listen` (https://github.com/zeit/test-listen) to create a url for each file.