### PR TITLE
Override host header by parsing dest string

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const micro = require('micro')
-const { resolve } = require('url')
+const { resolve, URL } = require('url')
 const fetch = require('node-fetch')
 const lintRules = require('./lib/lint-rules')
 
@@ -33,9 +33,13 @@ module.exports = (rules) => {
 
 async function proxyRequest (req, res, dest) {
   const newUrl = resolve(dest, req.url)
+  const url = new URL(dest)
   const proxyRes = await fetch(newUrl, {
     method: req.method,
-    headers: req.headers,
+    headers: {
+      ...req.headers,
+      host: url.host
+    },
     body: req
   })
 

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -167,6 +167,27 @@ describe('Basic Proxy Operations', () => {
       s1.close()
     })
 
+    it('should override host header using dest', async () => {
+      const s1 = await createInfoServer()
+      const proxy = createProxy([
+        { pathname: '/blog/**', dest: s1.url }
+      ])
+      await listen(proxy)
+
+      const { data } = await fetchProxy(proxy, '/blog/hello', {
+        method: 'POST',
+        headers: {
+          host: 'my-host.com'
+        }
+      })
+
+      expect(data.headers['host']).not.toBe('my-host.com')
+      expect(data.headers['host']).toContain('localhost')
+
+      proxy.close()
+      s1.close()
+    })
+
     it('should forward original status code', async () => {
       const s1 = await createInfoServer()
       const proxy = createProxy([


### PR DESCRIPTION
Hi, I had some issues with SSL when proxying from localhost directly to a https hostname.
I was getting this error:
```
FetchError: request to https://www.hostname.com/api/path failed, reason: Hostname/IP doesn't match certificate's altnames: "Host: localhost. is not in the cert's altnames: DNS:www.hostname.com, DNS:hostname.com"
[0]     at ClientRequest.<anonymous> (/Users/tomaswitek/code/micro-example/node_modules/node-fetch/index.js:133:11)
[0]     at emitOne (events.js:120:20)
[0]     at ClientRequest.emit (events.js:210:7)
[0]     at TLSSocket.socketErrorListener (_http_client.js:385:9)
[0]     at emitOne (events.js:115:13)
[0]     at TLSSocket.emit (events.js:210:7)
[0]     at emitErrorNT (internal/streams/destroy.js:64:8)
[0]     at _combinedTickCallback (internal/process/next_tick.js:138:11)
[0]     at process._tickCallback (internal/process/next_tick.js:180:9)
```

The problem is that currently is `micro-proxy` sending always `localhost` as `host` header.
In my opinion it should send the same hostname which is defined in `dest` rule option.

This PR should fix it. 