### PR TITLE
Make proxy node-fetch redirect behavior configurable

### DIFF
--- a/lib/lint-rules.js
+++ b/lib/lint-rules.js
@@ -3,8 +3,9 @@
 const { METHODS: HTTP_METHODS } = require('http')
 const { parse } = require('url')
 
-const ALLOWED_KEYS = new Set(['method', 'pathname', 'dest'])
+const ALLOWED_KEYS = new Set(['method', 'pathname', 'dest', 'handleRedirects'])
 const ALLOWED_METHODS = new Set(HTTP_METHODS)
+const ALLOWED_REDIRECT_TYPES = new Set(['follow', 'manual', 'error'])
 const MAX_RULES_LIMIT = 20
 
 module.exports = function lintRules (rules) {
@@ -26,6 +27,7 @@ module.exports = function lintRules (rules) {
     rule = lintAndFixMethods(rule)
     rule = lintDest(rule)
     rule = lintAndFixPathname(rule)
+    rule = lintHandleRedirects(rule)
     cleanedRules.push(rule)
   }
 
@@ -122,6 +124,22 @@ function lintAndFixPathname (rule) {
     pathnameRe = pathnameRe.replace('?', '.') // ? -> .
 
     rule.pathnameRe = `^${pathnameRe}$`
+  }
+  return rule
+}
+
+function lintHandleRedirects (rule) {
+  if (
+    rule.handleRedirects &&
+    !ALLOWED_REDIRECT_TYPES.has(rule.handleRedirects)
+  ) {
+    const err = new Error(
+      `Illegal handleRedirects type ${JSON.stringify(
+        rule.handleRedirects
+      )}, allowed types: [${Array.from(ALLOWED_REDIRECT_TYPES)}]`
+    )
+    err.statusCode = 422
+    throw err
   }
   return rule
 }


### PR DESCRIPTION
The current default behavior to always follow redirects breaks oauth flows. This PR exposes an optional flag that makes the redirect behavior configurable per each entry via a `handleRedirects` flag:

```json
{
  "rules": [
    { "pathname": "/api/**", "dest": "http://backend:3000" },
    {
      "pathname": "/login",
      "dest": "http://github-auth:3000",
      "handleRedirects": "manual"
    },
    {
      "pathname": "/callback**",
      "dest": "http://github-auth:3000",
      "handleRedirects": "manual"
    },
    { "pathname": "/**", "dest": "http://frontend:3000" }
  ]
}

```