### PR TITLE
Use Object.assign instead of Object spread

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,10 +109,7 @@ async function proxyRequest (req, res, dest) {
   const url = new URL(dest)
   const proxyRes = await fetch(newUrl, {
     method: req.method,
-    headers: {
-      ...req.headers,
-      host: url.host
-    },
+    headers: Object.assign({}, req.headers, { host: url.host }),
     body: req,
     compress: false
   })


### PR DESCRIPTION
Avoid error which in node version not support Object spread.
To work with [pkg](https://zeit.co/pkg), need to remove Object spread.