### PR TITLE
Add support for redirect rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,10 @@ module.exports = (rules) => {
 
   const server = micro(async (req, res) => {
     try {
+      if (res.headersSent) {
+        return
+      }
+
       const dest = getDest(req)
 
       if (!dest) {

--- a/lib/lint-rules.js
+++ b/lib/lint-rules.js
@@ -3,7 +3,7 @@
 const { METHODS: HTTP_METHODS } = require('http')
 const { parse } = require('url')
 
-const ALLOWED_KEYS = new Set(['method', 'pathname', 'dest'])
+const ALLOWED_KEYS = new Set(['method', 'pathname', 'dest', 'redirect'])
 const ALLOWED_METHODS = new Set(HTTP_METHODS)
 const MAX_RULES_LIMIT = 20
 
@@ -77,6 +77,10 @@ function lintMethods (methods) {
 }
 
 function lintDest (rule) {
+  if (rule.redirect) {
+    return rule
+  }
+
   if (!rule.dest) {
     const err = new Error(`Missing destination ${JSON.stringify(rule)}`)
     err.statusCode = 422


### PR DESCRIPTION
This allows setting redirect rules, for example to add a trailing slash:

```js
const proxy = createProxy([{
  pathname: "/blog/",
  dest: "http://localhost:3000"
}, {
  pathname: "/blog",
  redirect: "/blog/"
}]);
```