### PR TITLE
Don’t follow redirects

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,8 @@ async function proxyRequest (req, res, dest) {
     method: req.method,
     headers: Object.assign({}, req.headers, { host: url.host }),
     body: req,
-    compress: false
+    compress: false,
+    redirect: 'manual'
   })
 
   // Forward status code

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -224,5 +224,32 @@ describe('Basic Proxy Operations', () => {
       proxy.close()
       s1.close()
     })
+
+    it('should send back redirects', async () => {
+      const s1 = micro(async (req, res) => {
+        res.writeHead(302, {
+          'location': 'http://localhost/other-blog/hello'
+        })
+        res.end()
+      })
+      await listen(s1)
+
+      const s2 = await createInfoServer()
+
+      const proxy = createProxy([
+        { pathname: '/blog/**', dest: `http://localhost:${s1.address().port}` },
+        { pathname: '/other-blog/**', dest: s2.url }
+      ])
+      await listen(proxy)
+
+      const { res } = await fetchProxy(proxy, '/blog/hello')
+
+      expect(res.status).toBe(302)
+      expect(res.headers.get('location')).toBe('http://localhost/other-blog/hello')
+
+      proxy.close()
+      s1.close()
+      s2.close()
+    })
   })
 })

--- a/test/util.js
+++ b/test/util.js
@@ -72,7 +72,7 @@ exports.receiveWsMessageOnce = async (ws, message) => new Promise(resolve => {
   })
 })
 
-exports.fetchProxy = async (proxy, path, options) => {
+exports.fetchProxy = async (proxy, path, options = { redirect: 'manual' }) => {
   const res = await fetch(`http://localhost:${proxy.address().port}${path}`, options)
   if (res.status !== 200) {
     return { res }


### PR DESCRIPTION
When proxying a request, one would not expect the proxy server to follow redirects and return the final destination, but rather to pass the redirect back to the client so _it_ can decide to follow it.

This change makes that happen, bringing micro-proxy more in line with how the now path alias feature works.

### Why?

In addition to the reasons mentioned in other PRs like #17, in our particular case we ran into this when our backend tried to set a cookie when redirecting (logging in), but the response (and 'Set-Cookie'-header) was swallowed by the proxy.

### Alternatives

There's already a PR that makes this configurable (#17), but I opted to change the default behavior instead in the spirit of making this proxy behave more like the now path alias feature works, which seems to be a goal of the project.