### PR TITLE
Set x-forwarded-host header

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ async function proxyRequest (req, res, dest) {
   const url = new URL(dest)
   const proxyRes = await fetch(newUrl, {
     method: req.method,
-    headers: Object.assign({}, req.headers, { host: url.host }),
+    headers: Object.assign({ 'x-forwarded-host': req.headers.host }, req.headers, { host: url.host }),
     body: req,
     compress: false
   })

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -188,6 +188,26 @@ describe('Basic Proxy Operations', () => {
       s1.close()
     })
 
+    it('should set host forwarded header', async () => {
+      const s1 = await createInfoServer()
+      const proxy = createProxy([
+        { pathname: '/blog/**', dest: s1.url }
+      ])
+      await listen(proxy)
+
+      const { data } = await fetchProxy(proxy, '/blog/hello', {
+        method: 'POST',
+        headers: {
+          host: 'my-host.com:9000'
+        }
+      })
+
+      expect(data.headers['x-forwarded-host']).toContain('my-host.com:9000')
+
+      proxy.close()
+      s1.close()
+    })
+
     it('should forward original status code', async () => {
       const s1 = await createInfoServer()
       const proxy = createProxy([


### PR DESCRIPTION
In the spirit of behaving closer to how the Path Aliases features behaves, this PR sets the `'X-Forwarded-Host'` header to reflect the originally requested host, [just like now path alias does](https://zeit.co/docs/features/path-aliases#dest):

> You can get the original hostname from the `x-forwarded-host` header.