### PR TITLE
Accept rewrites in rule - Fixes #21

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const lintRules = require('./lib/lint-rules')
 const WebSocket = require('ws')
 
 module.exports = (rules) => {
-  const lintedRules = lintRules(rules).map(({pathname, pathnameRe, method, dest, rewrites}) => {
+  const lintedRules = lintRules(rules).map(({ pathname, pathnameRe, method, dest, rewrites }) => {
     const methods = method ? method.reduce((final, c) => {
       final[c.toLowerCase()] = true
       return final
@@ -14,14 +14,14 @@ module.exports = (rules) => {
     return {
       pathname,
       pathnameRegexp: new RegExp(pathnameRe || pathname || '.*'),
-      rewrites, 
+      rewrites,
       dest,
       methods
     }
   })
 
   const getData = (req, prop) => {
-    for (const [index, {pathnameRegexp, methods}] of lintedRules.entries()) {
+    for (const [index, { pathnameRegexp, methods }] of lintedRules.entries()) {
       if (pathnameRegexp.test(req.url) && (!methods || methods[req.method.toLowerCase()])) {
         return lintedRules[index][prop]
       }
@@ -41,9 +41,9 @@ module.exports = (rules) => {
       const rewrites = getData(req, 'rewrites')
 
       // Apply URL rewrites
-      if(rewrites) {
+      if (rewrites) {
         req.url = rewrites.reduce((acc, rewrite) => {
-          return acc.replace(rewrite.reg, rewrite.rep);
+          return acc.replace(rewrite.reg, rewrite.rep)
         }, req.url)
       }
 

--- a/lib/lint-rules.js
+++ b/lib/lint-rules.js
@@ -3,7 +3,7 @@
 const { METHODS: HTTP_METHODS } = require('http')
 const { parse } = require('url')
 
-const ALLOWED_KEYS = new Set(['method', 'pathname', 'dest'])
+const ALLOWED_KEYS = new Set(['method', 'pathname', 'dest', 'rewrites'])
 const ALLOWED_METHODS = new Set(HTTP_METHODS)
 const MAX_RULES_LIMIT = 20
 
@@ -26,6 +26,7 @@ module.exports = function lintRules (rules) {
     rule = lintAndFixMethods(rule)
     rule = lintDest(rule)
     rule = lintAndFixPathname(rule)
+    rule = lintRewrites(rule)
     cleanedRules.push(rule)
   }
 
@@ -124,4 +125,41 @@ function lintAndFixPathname (rule) {
     rule.pathnameRe = `^${pathnameRe}$`
   }
   return rule
+}
+
+function lintRewrites(rule) {
+	if (!rule.rewrites) {
+		return rule
+	}
+
+  const rewrites = Object.keys(rule.rewrites)
+
+	if (rewrites.length) {
+		rule.rewrites = rewrites.map(exp => {
+			let reg
+
+			// Pattern test
+			try {
+				reg = new RegExp(exp);
+			} catch (error) {
+				const err = new Error(`Expression '${exp}' is invalid for ${JSON.stringify(rule)}`)
+				err.statusCode = 422
+				throw err
+			}
+
+			// Replacer test
+			const rep = rule.rewrites[exp];
+			if (typeof rep !== 'string') {
+				const err = new Error(`Replacement ${rep} for the rewrites '${exp}' is not a valid string for ${JSON.stringify(rule)}`)
+				err.statusCode = 422
+				throw err
+      }
+      
+      return {
+        reg, rep
+      }
+    })
+  }
+  
+  return rule;
 }

--- a/readme.md
+++ b/readme.md
@@ -20,12 +20,14 @@ Then add following rules to a filename called `rules.json`:
 {
   "rules": [
     {"pathname": "/blog", "method":["GET", "POST", "OPTIONS"], "dest": "http://localhost:5000"},
+    {"pathname": "/main/blog", "dest": "http://localhost:5000", "rewrites": { "^/main" : "" }},
     {"pathname": "/**", "dest": "http://localhost:4000"}
   ]
 }
 ```
 
 > Visit [path alias](https://zeit.co/docs/features/path-aliases) documentation to learn more about rules.
+> `rewrites` is similar to [`pathRewrite`](https://webpack.js.org/configuration/dev-server/#devserver-proxy) from webpack
 
 Run the proxy server with:
 

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -80,6 +80,20 @@ describe('Basic Proxy Operations', () => {
       proxy.close()
       s1.close()
     })
+
+    it('should proxy with all url rewrites', async () => {
+      const s1 = await createInfoServer()
+      const proxy = createProxy([
+        { pathname: '/abc/blog/**', dest: s1.url, rewrites: {'^/abc': ''}}
+      ])
+      await listen(proxy)
+      
+      const { data } = await fetchProxy(proxy, '/abc/blog/nice-one')
+      expect(data.url).toBe('/blog/nice-one')
+
+      proxy.close()
+      s1.close()
+    })
   })
 
   describe('methods', () => {

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -84,10 +84,10 @@ describe('Basic Proxy Operations', () => {
     it('should proxy with all url rewrites', async () => {
       const s1 = await createInfoServer()
       const proxy = createProxy([
-        { pathname: '/abc/blog/**', dest: s1.url, rewrites: {'^/abc': ''}}
+        { pathname: '/abc/blog/**', dest: s1.url, rewrites: { '^/abc': '' } }
       ])
       await listen(proxy)
-      
+
       const { data } = await fetchProxy(proxy, '/abc/blog/nice-one')
       expect(data.url).toBe('/blog/nice-one')
 


### PR DESCRIPTION
Introduces a basic feature to accept `rewrites`  in a rule  which functions similar to [webpack's `pathRewrite`](https://webpack.js.org/configuration/dev-server/#devserver-proxy). Like so - 

```json
{
  "rules": [
    {
      "pathname": "/main/blog",
      "dest": "http://localhost:5000",
      "rewrites": {
        "^/main" : ""
      }
    }
  ]
}
```

Checks -
1. Each key under `rewrites` must be a valid `RegExp` string to be used in `const exp = new RegExp()`
2. Each key should have a value (say `rep`) that is also a valid string to be used in `MY_STRING.replace(exp, rep)`